### PR TITLE
[WIP] Make log_directory behavior uniform

### DIFF
--- a/clusterlib/scheduler.py
+++ b/clusterlib/scheduler.py
@@ -149,7 +149,12 @@ _SGE_TEMPLATE = {
     "email": "-M %s",
     "email_options": "-m %s",
     # "-j y" is used to join stderr and stdout in the same log file
-    "log_directory": "-j y -o %s/$JOB_NAME.$JOB_ID.txt",
+    # the simple quotes around the filename are required to avoid
+    # variables interpolation by the shell when submitting the command.
+    # $JOB_NAME and $JOB_ID are pseudo-environment variables at this point:
+    # the qsub command it-self is responsible for doing the interpolation
+    # in the filename.
+    "log_directory": "-j y -o '%s/$JOB_NAME.$JOB_ID.txt'",
 }
 
 _SLURM_TEMPLATE = {

--- a/clusterlib/scheduler.py
+++ b/clusterlib/scheduler.py
@@ -148,7 +148,8 @@ _SGE_TEMPLATE = {
     "time": "-l h_rt=%s",
     "email": "-M %s",
     "email_options": "-m %s",
-    "log_directory": "-o %s/$JOB_NAME.$JOB_ID",
+    # "-j y" is used to join stderr and stdout in the same log file
+    "log_directory": "-j y -o %s/$JOB_NAME.$JOB_ID.txt",
 }
 
 _SLURM_TEMPLATE = {
@@ -157,7 +158,7 @@ _SLURM_TEMPLATE = {
     "time": "--time=%s",
     "email": "--mail-user=%s",
     "email_options": "--mail-type=%s",
-    "log_directory": "-o %s/%s.txt",
+    "log_directory": "-o %s/%s.%%j.txt",
 }
 
 _TEMPLATE = {

--- a/clusterlib/scheduler.py
+++ b/clusterlib/scheduler.py
@@ -260,7 +260,8 @@ def submit(job_command, job_name="job", time="24:00:00", memory=4000,
     if email_options:
         job_options.append(template["email_options"] % email_options)
 
-    if log_directory:
+    if log_directory is not None:
+        log_directory = os.path.abspath(log_directory)
         if backend == "sge":
             job_options.append(template["log_directory"] % log_directory)
         elif backend == "slurm":

--- a/clusterlib/testing.py
+++ b/clusterlib/testing.py
@@ -1,0 +1,78 @@
+"""Utilities for testing
+
+Note: this module has a dependency on the nose package.
+
+"""
+# Authors: Olivier Grisel
+#
+# License: BSD 3 clause
+import shutil
+import os
+import warnings
+from tempfile import mkdtemp
+
+from nose import SkipTest
+from nose.tools import with_setup
+
+from clusterlib.scheduler import _get_backend
+
+SHARED_TEST_FOLDER = os.environ.get('CLUSTERLIB_TEST_SHARED_FOLDER', '.')
+DELETE_TEST_FOLDER = int(os.environ.get('CLUSTERLIB_DELETE_TEST_FOLDER', 1))
+TEMP_FOLDER_PREFIX = "clusterlib_test_"
+
+
+class TemporaryDirectory(object):
+    """Create and return a temporary directory.  This has the same
+    behavior as mkdtemp but can be used as a context manager.  For
+    example:
+
+        with TemporaryDirectory() as tmpdir:
+            ...
+
+    Upon exiting the context, the directory and everything contained
+    in it are removed.
+
+    Note: this class backported and adapted from the Python 3.4 stdlib for
+    backward compat of the tests with Python 2.
+
+    """
+
+    # Handle mkdtemp raising an exception
+    name = None
+    _closed = False
+
+    def __init__(self, suffix="", prefix=TEMP_FOLDER_PREFIX,
+                 dir=SHARED_TEST_FOLDER, delete_on_exit=DELETE_TEST_FOLDER):
+        self.name = mkdtemp(suffix, prefix, dir)
+        self.delete_on_exit = delete_on_exit
+
+    @classmethod
+    def _cleanup(cls, name, warn_message=None):
+        shutil.rmtree(name)
+        if warn_message is not None:
+            warnings.warn(warn_message, ResourceWarning)
+
+    def __repr__(self):
+        return "<{} {!r}>".format(self.__class__.__name__, self.name)
+
+    def __enter__(self):
+        return self.name
+
+    def __exit__(self, exc, value, tb):
+        if self.delete_on_exit:
+            self.cleanup()
+
+    def cleanup(self):
+        if self.name is not None and not self._closed:
+            shutil.rmtree(self.name)
+            self._closed = True
+
+
+def _skip_if_no_backend():
+    try:
+        _get_backend(backend='auto')
+    except RuntimeError:
+        raise SkipTest('A scheduler backend is required for this test.')
+
+
+skip_if_no_backend = with_setup(_skip_if_no_backend)

--- a/clusterlib/tests/test_scheduler.py
+++ b/clusterlib/tests/test_scheduler.py
@@ -124,9 +124,6 @@ def test_log_output():
                 if _get_backend('auto') == 'slurm':
                     subprocess.call(["scancel", job_id])
                 else:
-                    print(subprocess.check_output(["qhost"]).decode('utf-8'))
-                    print(subprocess.check_output(
-                        ["qstat", "-j", job_id]).decode('utf-8'))
                     subprocess.call(["qdel", job_id])
                 raise AssertionError(
                     "job %s (%s) has not completed after 5min."

--- a/clusterlib/tests/test_scheduler.py
+++ b/clusterlib/tests/test_scheduler.py
@@ -125,7 +125,8 @@ def test_log_output():
                     subprocess.call(["scancel", job_id])
                 else:
                     print(subprocess.check_output(["qhost"]).decode('utf-8'))
-                    print(subprocess.check_output(["qstat"]).decode('utf-8'))
+                    print(subprocess.check_output(
+                        ["qstat", "-j", job_id]).decode('utf-8'))
                     subprocess.call(["qdel", job_id])
                 raise AssertionError(
                     "job %s (%s) has not completed after 5min."

--- a/clusterlib/tests/test_scheduler.py
+++ b/clusterlib/tests/test_scheduler.py
@@ -185,12 +185,13 @@ def test_submit():
         submit(job_command="python main.py", log_directory="path/test",
                backend="sge"),
         'echo \'#!/bin/bash\npython main.py\' | qsub -N "job" '
-        '-l h_rt=24:00:00 -l h_vmem=4000M -o path/test/$JOB_NAME.$JOB_ID')
+        '-l h_rt=24:00:00 -l h_vmem=4000M -j y '
+        '-o path/test/$JOB_NAME.$JOB_ID.txt')
 
     assert_equal(
         submit(job_command="python main.py", log_directory="path/test",
                backend="slurm"),
         "echo \'#!/bin/bash\npython main.py\' | sbatch --job-name=job "
-        "--time=24:00:00 --mem=4000 -o path/test/job.txt")
+        "--time=24:00:00 --mem=4000 -o path/test/job.%j.txt")
 
     assert_raises(ValueError, submit, job_command="", backend="unknown")

--- a/clusterlib/tests/test_scheduler.py
+++ b/clusterlib/tests/test_scheduler.py
@@ -204,16 +204,16 @@ def test_submit():
         '-l h_rt=24:00:00 -l h_vmem=4000M -M test@test.com -m beas')
 
     assert_equal(
-        submit(job_command="python main.py", log_directory="path/test",
+        submit(job_command="python main.py", log_directory="/path/test",
                backend="sge"),
         'echo \'#!/bin/bash\npython main.py\' | qsub -N "job" '
         '-l h_rt=24:00:00 -l h_vmem=4000M -j y '
-        '-o \'path/test/$JOB_NAME.$JOB_ID.txt\'')
+        '-o \'/path/test/$JOB_NAME.$JOB_ID.txt\'')
 
     assert_equal(
-        submit(job_command="python main.py", log_directory="path/test",
+        submit(job_command="python main.py", log_directory="/path/test",
                backend="slurm"),
         "echo \'#!/bin/bash\npython main.py\' | sbatch --job-name=job "
-        "--time=24:00:00 --mem=4000 -o path/test/job.%j.txt")
+        "--time=24:00:00 --mem=4000 -o /path/test/job.%j.txt")
 
     assert_raises(ValueError, submit, job_command="", backend="unknown")

--- a/clusterlib/tests/test_scheduler.py
+++ b/clusterlib/tests/test_scheduler.py
@@ -105,7 +105,7 @@ def test_log_output():
                               time="700", memory=500,
                               log_directory=temp_folder)
         try:
-            for i in range(60):
+            for i in range(30):
                 if job_name not in queued_or_running_jobs(user=user):
                     # job has completed, let's check the output
                     job_completed = True
@@ -124,6 +124,8 @@ def test_log_output():
                 if _get_backend('auto') == 'slurm':
                     subprocess.call(["scancel", job_id])
                 else:
+                    print(subprocess.check_output(["qhost"]).decode('utf-8'))
+                    print(subprocess.check_output(["qstat"]).decode('utf-8'))
                     subprocess.call(["qdel", job_id])
                 raise AssertionError(
                     "job %s (%s) has not completed after 5min."

--- a/clusterlib/tests/test_scheduler.py
+++ b/clusterlib/tests/test_scheduler.py
@@ -90,10 +90,10 @@ def test_queued_or_running_jobs_no_backend():
     assert_equal(queued_or_running_jobs(), [])
 
 
-def test_log_output_sge():
-    # Check that SGE is installed
-    if _which('qsub') is None:
-        raise SkipTest("qsub (sge) is missing")
+def test_log_output():
+    # Check that a scheduler is installed
+    if _which('qsub') is None and _which('sbatch') is None:
+        raise SkipTest("qsub (sge) or sbatch (slurm) is missing")
 
     with TemporaryDirectory() as temp_folder:
 
@@ -102,10 +102,10 @@ def test_log_output_sge():
         # Launch a sleepy SGE job
         job_name = 'ok_job'
         job_id = _do_dispatch(job_command="echo ok", job_name=job_name,
-                              backend="sge", time="700", memory=500,
+                              time="700", memory=500,
                               log_directory=temp_folder)
         try:
-            for i in range(10):
+            for i in range(60):
                 if job_name not in queued_or_running_jobs(user=user):
                     # job has completed, let's check the output
                     job_completed = True
@@ -116,14 +116,18 @@ def test_log_output_sge():
                     break
                 else:
                     # Let's wait a bit before retrying
-                    sleep(10)
+                    sleep(5)
 
         finally:
             # Make sure to clean up even if there is a failure
             if not job_completed:
-                subprocess.call(["qdel", job_id])
-                raise AssertionError("job %s (%s) has not completed."
-                                     % (job_id, job_name))
+                if _get_backend('auto') == 'slurm':
+                    subprocess.call(["scancel", job_id])
+                else:
+                    subprocess.call(["qdel", job_id])
+                raise AssertionError(
+                    "job %s (%s) has not completed after 5min."
+                    % (job_id, job_name))
 
 
 def check_job_name_queued_or_running_sge(job_name):

--- a/clusterlib/tests/test_scheduler.py
+++ b/clusterlib/tests/test_scheduler.py
@@ -4,19 +4,40 @@
 from __future__ import unicode_literals
 
 import os
+import os.path as op
+from time import sleep
 import subprocess
 from getpass import getuser
-from xml.etree.ElementTree import XMLParser, XML
 
 from nose.tools import assert_equal
 from nose.tools import assert_raises
 from nose.tools import assert_in
 from nose import SkipTest
 
-from ..scheduler import queued_or_running_jobs
-from ..scheduler import submit
-from ..scheduler import _which
-from ..scheduler import _get_backend
+from clusterlib.scheduler import queued_or_running_jobs
+from clusterlib.scheduler import submit
+from clusterlib.scheduler import _which
+from clusterlib.scheduler import _get_backend
+from clusterlib.testing import TemporaryDirectory
+
+
+def _do_dispatch(*args, **kwargs):
+    """Perform a dispatch with the submit command and return the job id"""
+    # TODO: This utility function should be properly documented any made more
+    # robust to be included in the scheduler module itself
+    cmd = submit(*args, **kwargs)
+    cmd_encoding = 'utf-8'
+    output = subprocess.check_output(
+        cmd.encode(cmd_encoding), shell=True).decode(cmd_encoding)
+    if output.startswith(u'Your job '):
+        job_id = output.split()[2]
+    elif output.startswith(u'Submitted batch job '):
+        job_id = output.split()[3]
+    else:
+        raise RuntimeError(
+            u"Failed to parse job_id from command output:\n %s\ncmd:\n%s"
+            % (cmd, output))
+    return job_id
 
 
 def test_auto_backend():
@@ -69,45 +90,61 @@ def test_queued_or_running_jobs_no_backend():
     assert_equal(queued_or_running_jobs(), [])
 
 
+def test_log_output_sge():
+    # Check that SGE is installed
+    if _which('qsub') is None:
+        raise SkipTest("qsub (sge) is missing")
+
+    with TemporaryDirectory() as temp_folder:
+
+        user = getuser()
+        job_completed = False
+        # Launch a sleepy SGE job
+        job_name = 'ok_job'
+        job_id = _do_dispatch(job_command="echo ok", job_name=job_name,
+                              backend="sge", time="700", memory=500,
+                              log_directory=temp_folder)
+        try:
+            for i in range(10):
+                if job_name not in queued_or_running_jobs(user=user):
+                    # job has completed, let's check the output
+                    job_completed = True
+                    filename = "%s.%s.txt" % (job_name, job_id)
+                    assert_equal(os.listdir(temp_folder), [filename])
+                    with open(op.join(temp_folder, filename)) as f:
+                        assert_equal(f.read().strip(), "ok")
+                    break
+                else:
+                    # Let's wait a bit before retrying
+                    sleep(10)
+
+        finally:
+            # Make sure to clean up even if there is a failure
+            if not job_completed:
+                subprocess.call(["qdel", job_id])
+                raise AssertionError("job %s (%s) has not completed."
+                                     % (job_id, job_name))
+
+
 def check_job_name_queued_or_running_sge(job_name):
     # Check that SGE is installed
     if _which('qsub') is None:
         raise SkipTest("qsub (sge) is missing")
 
-    user = getuser()
-    # Launch a sleepy slurm job
-    sleep_job = submit(job_command="sleep 600", job_name=job_name,
-                       backend="sge", time="700", memory=100)
+    with TemporaryDirectory() as temp_folder:
 
-    # Encoding to UTF-8 is required when passing job_name with non-ASCII chars
-    os.system(sleep_job.encode('utf-8'))
-
-    # Get job id
-    job_id = None
-    try:
-        out = subprocess.check_output(["qstat", "-xml", "-u", user, "-j",
-                                       job_name])
-        tree = XML(out, parser=XMLParser(encoding='utf-8'))
-        for id_, name in zip(tree.iter("JB_job_number"),
-                             tree.iter("JB_name")):
-            if name.text == job_name:
-                job_id = id_.text[0]
-                break
-
-    except subprocess.CalledProcessError as error:
-        print(error.output)
-        raise
-
-    # Assert that the job has been launched
-    try:
-        running_jobs = queued_or_running_jobs(user=user)
-        assert_in(job_name, running_jobs)
-    finally:
-        # Make sure to clean up even if there is a failure
-        if job_id is not None:
+        user = getuser()
+        # Launch a sleepy SGE job
+        job_id = _do_dispatch(job_command="sleep 600", job_name=job_name,
+                              backend="sge", time="700", memory=500,
+                              log_directory=temp_folder)
+        # Assert that the job has been launched
+        try:
+            running_jobs = queued_or_running_jobs(user=user)
+            assert_in(job_name, running_jobs)
+        finally:
+            # Make sure to clean up even if there is a failure
             subprocess.call(["qdel", job_id])
-        if os.path.exists("%s.%s" % (job_name, job_id)):
-            os.remove("%s.%s" % (job_name, job_id))
 
 
 def check_job_name_queued_or_running_slurm(job_name):
@@ -118,41 +155,19 @@ def check_job_name_queued_or_running_slurm(job_name):
         raise SkipTest("sbatch (SLURM) is missing")
 
     user = getuser()
+    with TemporaryDirectory() as temp_folder:
+        # Launch a sleepy slurm job
+        job_id = _do_dispatch(job_command="sleep 600", job_name=job_name,
+                              backend="slurm", time="10:00", memory=500,
+                              log_directory=temp_folder)
 
-    # Launch a sleepy slurm job
-    sleep_job = submit(job_command="sleep 600", job_name=job_name,
-                       backend="slurm", time="10:00", memory=100)
-
-    # Encoding to UTF-8 is required when passing job_name with non-ASCII chars
-    os.system(sleep_job.encode('utf-8'))
-
-    # Get job id
-    job_id = None
-    try:
-        out = subprocess.check_output(['squeue', '--noheader', '-o', '%j %i',
-                                       '-u', user])
-        for line in out.splitlines():
-            name, id_ = line.decode("utf8").split()
-
-            if job_name == name:
-                job_id = id_
-                break
-
-    except subprocess.CalledProcessError as error:
-        print(error.output)
-        raise
-
-    # Assert that the job has been launched
-    try:
-        running_jobs = queued_or_running_jobs(user=user)
-        assert_in(job_name, running_jobs)
-    finally:
-        # Make sure to clean up even if there is a failure
-        if job_id is not None:
+        # Assert that the job has been launched
+        try:
+            running_jobs = queued_or_running_jobs(user=user)
+            assert_in(job_name, running_jobs)
+        finally:
+            # Make sure to clean up even if there is a failure
             subprocess.call(["scancel", job_id])
-
-        if os.path.exists("slurm-%s.out" % job_id):
-            os.remove("slurm-%s.out" % job_id)
 
 
 def test_queued_or_running_jobs():
@@ -186,7 +201,7 @@ def test_submit():
                backend="sge"),
         'echo \'#!/bin/bash\npython main.py\' | qsub -N "job" '
         '-l h_rt=24:00:00 -l h_vmem=4000M -j y '
-        '-o path/test/$JOB_NAME.$JOB_ID.txt')
+        '-o \'path/test/$JOB_NAME.$JOB_ID.txt\'')
 
     assert_equal(
         submit(job_command="python main.py", log_directory="path/test",


### PR DESCRIPTION
Ensure that the log files are consistent across schedulers and started to write some tests. In particular the filenames are uniform and the `stdout` and `stderr` streams are joined on SGE (as for the default behavior of SLURM).

TODO before `[MRG]`:

- [x] more tests (slurm logs are not tested)
- [x] debug SGE failures on travis
- [ ] update the documentation where necessary
- [ ] improve code quality based on landscape report