### PR TITLE
ENH optional overwrite

### DIFF
--- a/clusterlib/storage.py
+++ b/clusterlib/storage.py
@@ -139,6 +139,11 @@ def sqlite3_dumps(dictionnary, file_name, timeout=7200.0, overwrite=False):
         The timeout parameter specifies how long the connection should wait
         for the lock to go away until raising an exception.
 
+    overwrite : bool, optional (default=False)
+        Whether to overwrite the value associated to a key already present
+        in the database. If True, the value is replaced in case of conflict.
+        If False, an IntegrityError is raised in case of conflict.
+
     Examples
     --------
     Here, we generate a temporary sqlite3 database, then dump some data in it.

--- a/clusterlib/storage.py
+++ b/clusterlib/storage.py
@@ -117,7 +117,7 @@ def sqlite3_loads(file_name, key=None, timeout=7200.0):
     return out
 
 
-def sqlite3_dumps(dictionnary, file_name, timeout=7200.0):
+def sqlite3_dumps(dictionnary, file_name, timeout=7200.0, overwrite=False):
     """Dump value with key in the sqlite3 database.
 
     In order to improve performance, it's advised to dump into the database as
@@ -160,5 +160,10 @@ def sqlite3_dumps(dictionnary, file_name, timeout=7200.0):
                               (key TEXT PRIMARY KEY, value BLOB)""")
 
         # Add a new key
-        connection.executemany("INSERT INTO dict(key, value) VALUES (?, ?)",
-                               compressed_dict.items())
+        if overwrite:
+            connection.executemany("INSERT OR REPLACE INTO dict(key, value)"
+                                   "VALUES (?, ?)",
+                                   compressed_dict.items())
+        else:
+            connection.executemany("INSERT INTO dict(key, value) VALUES (?, ?)",
+                                   compressed_dict.items())

--- a/clusterlib/tests/test_storage.py
+++ b/clusterlib/tests/test_storage.py
@@ -40,8 +40,12 @@ def test_sqlite3_storage():
                      {"complex": complex_object})
 
         # Try to insert object twice
+            # By default, raise an integrety error
         assert_raises(sqlite3.IntegrityError, sqlite3_dumps,
                       {"complex": complex_object}, fname)
+            # Can be overwritten
+        sqlite3_dumps({"complex": complex_object}, fname, overwrite=True)
+
 
         # Ensure that we can store None
         sqlite3_dumps({"None": None}, fname)

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -34,6 +34,11 @@ Changelog
       SGE (as for the default behavior of SLURM).
       By `Olivier Grisel`_
 
+    - Add the possibility to overwrite a value associated to a key already
+      present in the database in :func:`storage.sqlite3_dumps` instead of
+      raising an IntegrityError.
+      By `Jean Michel Begon`_
+
 0.1
 ===
 


### PR DESCRIPTION
New feature: a dump in the database with a key already present can raise an error (as before) or can be overwrite the previous entry.